### PR TITLE
Switch to /save/ URL for Internet Archive Wayback Machine

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -7,9 +7,7 @@ chrome.action.onClicked.addListener(async (tab) => {
       active: false,
     });
     await chrome.tabs.create({
-      url: `https://web.archive.org/web/${new Date().getFullYear()}0000000000*/${
-        tab.url
-      }`,
+      url: `https://web.archive.org/save/${tab.url}`,
       index: tab.index + 2,
       active: false,
     });


### PR DESCRIPTION
Closes #105

The screenshot (and maybe description) needs to be updated in the Chrome Web Store:

![Screenshot 2024-08-17 at 17 32 23](https://github.com/user-attachments/assets/45d93ea9-503a-4e43-b792-b5f01aff0d61)
