### PR TITLE
Switch to pnpm v10.3.0 strict-dep-builds setting

### DIFF
--- a/.github/workflows/lint-check-types-and-build.yml
+++ b/.github/workflows/lint-check-types-and-build.yml
@@ -13,12 +13,7 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - name: Install dependencies
-        # Fail on pnpm v10 ignored build scripts
-        #
-        # TODO: Switch to future `pnpm install` option to fail on pnpm v10 ignored build scripts, if accepted:
-        # - https://github.com/pnpm/pnpm/issues/9032#issuecomment-2647428724
-        # run: pnpm install --<flag here>
-        run: pnpm install | { has_ignored_build_scripts=false; while IFS= read -r line; do echo "$line"; [[ "$line" == *"Ignored build scripts:"* ]] && has_ignored_build_scripts=true; done; [[ "$has_ignored_build_scripts" = false ]]; }
+        run: pnpm install
       - run: pnpm eslint . --max-warnings 0
       - run: pnpm tsc
       - run: pnpm tsc --project tsconfig.node.json --noEmit

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Fail on pnpm ignored build scripts
+# - https://github.com/pnpm/pnpm/pull/9071
+strict-dep-builds=true

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "5.7.3",
     "vite": "6.1.0"
   },
-  "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92",
+  "packageManager": "pnpm@10.3.0+sha512.ee592eda8815a8a293c206bb0917c4bb0ff274c50def7cbc17be05ec641fc2d1b02490ce660061356bd0d126a4d7eb2ec8830e6959fb8a447571c631d5a2442d",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"


### PR DESCRIPTION
Switch our workaround command to [the new pnpm v10.3.0 `strict-dep-builds` setting](https://github.com/pnpm/pnpm/pull/9071/#issuecomment-2650192097) to fail with a non-zero exit code when any build scripts for dependencies have been ignored:

```bash
$ cat ./.npmrc
# Fail on pnpm ignored build scripts
# - https://github.com/pnpm/pnpm/pull/9071
strict-dep-builds=true

$ pnpm install
...
 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
$ echo $?
1
```